### PR TITLE
Set font size to Jetbrains default value

### DIFF
--- a/Dracula.icls
+++ b/Dracula.icls
@@ -1,12 +1,12 @@
 <scheme name="Dracula" version="142" parent_scheme="Darcula">
   <option name="FONT_SCALE" value="1.0" />
-  <option name="LINE_SPACING" value="1.2" />
-  <option name="EDITOR_FONT_SIZE" value="16" />
+  <option name="LINE_SPACING" value="1.0" />
+  <option name="EDITOR_FONT_SIZE" value="12" />
   <option name="EDITOR_FONT_NAME" value="Fira Code" />
   <option name="EDITOR_LIGATURES" value="true" />
   <option name="CONSOLE_FONT_NAME" value="Monospaced" />
-  <option name="CONSOLE_FONT_SIZE" value="14" />
-  <option name="CONSOLE_LINE_SPACING" value="1.4" />
+  <option name="CONSOLE_FONT_SIZE" value="12" />
+  <option name="CONSOLE_LINE_SPACING" value="1.0" />
   <colors>
     <option name="CARET_COLOR" value="cccccc" />
     <option name="CARET_ROW_COLOR" value="44475a" />


### PR DESCRIPTION
The font size has been changed in PR #23, not sure if this was on purpose or an accident. The current font size is too big imo and this PR changes it back to the default Jetbrains values. 

Before:
![before change](https://user-images.githubusercontent.com/11406433/52335571-004fa980-2a03-11e9-9345-b62c126d6150.png)

After:
![after change](https://user-images.githubusercontent.com/11406433/52335620-207f6880-2a03-11e9-8296-ac0da6002706.png)
